### PR TITLE
Serve frontend via /static path

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2,12 +2,17 @@ import asyncio
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.staticfiles import StaticFiles
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, FileResponse
 
 from .capture import PacketCapture
 
 app = FastAPI(title="Visor")
-app.mount("/", StaticFiles(directory="frontend", html=True), name="frontend")
+app.mount("/static", StaticFiles(directory="frontend"), name="static")
+
+
+@app.get("/")
+def read_index():
+    return FileResponse("frontend/index.html")
 
 capture = PacketCapture()
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,12 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <title>Visor</title>
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
     <h1>VISOR</h1>
     <div id="graph"></div>
-    <script src="js/d3.min.js"></script>
-    <script src="app.js"></script>
+    <script src="/static/js/d3.min.js"></script>
+    <script src="/static/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- serve frontend assets under `/static`
- return `frontend/index.html` from the root route
- update HTML to use `/static/` asset paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dfc9a6c3483329db86af21c61b02e