### PR TITLE
Add connection-based packet data

### DIFF
--- a/backend/capture.py
+++ b/backend/capture.py
@@ -1,4 +1,4 @@
-from scapy.all import sniff, Packet
+from scapy.all import sniff, Packet, IP
 from threading import Thread, Event
 
 from typing import List
@@ -40,6 +40,24 @@ class PacketCapture:
     def get_summary_since(self, index: int) -> List[str]:
         """Return packet summaries starting from a given index."""
         return [p.summary() for p in self.packets[index:]]
+
+    def get_connections(self) -> List[dict]:
+        """Return a list of dicts with src and dst for IP packets."""
+        connections = []
+        for p in self.packets:
+            if IP in p:
+                ip_layer = p[IP]
+                connections.append({"src": ip_layer.src, "dst": ip_layer.dst})
+        return connections
+
+    def get_connections_since(self, index: int) -> List[dict]:
+        """Return src/dst dictionaries for packets since index."""
+        connections = []
+        for p in self.packets[index:]:
+            if IP in p:
+                ip_layer = p[IP]
+                connections.append({"src": ip_layer.src, "dst": ip_layer.dst})
+        return connections
 
     @property
     def size(self) -> int:

--- a/backend/main.py
+++ b/backend/main.py
@@ -29,7 +29,8 @@ def shutdown_event():
 
 @app.get("/packets")
 def get_packets():
-    return JSONResponse(capture.get_summary())
+    """Return all captured connections as src/dst dicts."""
+    return JSONResponse(capture.get_connections())
 
 
 @app.websocket("/ws")
@@ -39,7 +40,7 @@ async def websocket_endpoint(ws: WebSocket):
     try:
         while True:
             await asyncio.sleep(1)
-            new_packets = capture.get_summary_since(last)
+            new_packets = capture.get_connections_since(last)
             last = capture.size
             if new_packets:
                 await ws.send_json(new_packets)

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -70,12 +70,11 @@ function drag(simulation) {
 
 const ws = new WebSocket(`ws://${location.host}/ws`);
 ws.onmessage = (event) => {
-  const summaries = JSON.parse(event.data);
-  summaries.forEach(summary => {
-    const m = summary.match(/IP\s(\S+)\s>\s(\S+):/);
-    if (!m) return;
-    const src = m[1];
-    const dst = m[2];
+  const packets = JSON.parse(event.data);
+  packets.forEach(pkt => {
+    const src = pkt.src;
+    const dst = pkt.dst;
+    if (!src || !dst) return;
     if (!nodes.has(src)) nodes.set(src, {id: src});
     if (!nodes.has(dst)) nodes.set(dst, {id: dst});
     const key = `${src}->${dst}`;


### PR DESCRIPTION
## Summary
- return IP connection data from PacketCapture
- expose these connections via `/packets` API and websocket
- simplify frontend JS by using provided src/dst

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- manual PacketCapture test verifying TCP/UDP/ICMP packets return src/dst

------
https://chatgpt.com/codex/tasks/task_e_684e010eeff083329d867bbc567567d0