### PR TITLE
Add tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+      - name: Run tests
+        run: pytest -v

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+httpx

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,43 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from fastapi.testclient import TestClient
+from backend.main import app
+from unittest.mock import patch
+
+class DummyCapture:
+    def __init__(self):
+        self.sent = False
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def get_summary_since(self, index):
+        if not self.sent:
+            self.sent = True
+            return ["packet"]
+        return []
+
+    @property
+    def size(self):
+        return 1
+
+
+def test_read_index():
+    dummy = DummyCapture()
+    with patch("backend.main.capture", dummy):
+        with TestClient(app) as client:
+            resp = client.get("/")
+            assert resp.status_code == 200
+
+
+def test_websocket_endpoint_sends_data():
+    dummy = DummyCapture()
+    with patch("backend.main.capture", dummy):
+        with TestClient(app) as client:
+            with client.websocket_connect("/ws") as websocket:
+                data = websocket.receive_json()
+                assert data == ["packet"]
+


### PR DESCRIPTION
## Summary
- add pytest-based FastAPI tests
- include pytest and httpx in requirements-dev.txt
- run tests via GitHub Actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e0117504483328f7fdd78579c3ee2