### PR TITLE
Add thread-safe PacketCapture

### DIFF
--- a/backend/capture.py
+++ b/backend/capture.py
@@ -1,5 +1,5 @@
 from scapy.all import sniff, Packet, IP
-from threading import Thread, Event
+from threading import Thread, Event, Lock
 
 from typing import List
 
@@ -9,13 +9,18 @@ class PacketCapture:
         self.iface = iface
         self.count = count
         self.packets: List[Packet] = []
+        self._lock = Lock()
         self._stop_event = Event()
         self.thread: Thread | None = None
+
+    def _append_packet(self, packet: Packet):
+        with self._lock:
+            self.packets.append(packet)
 
     def _sniff(self):
         sniff(
             iface=self.iface,
-            prn=self.packets.append,
+            prn=self._append_packet,
             count=self.count,
             stop_filter=lambda _: self._stop_event.is_set(),
             store=False,
@@ -35,30 +40,35 @@ class PacketCapture:
         self._stop_event.clear()
 
     def get_summary(self) -> List[str]:
-        return [p.summary() for p in self.packets]
+        with self._lock:
+            return [p.summary() for p in self.packets]
 
     def get_summary_since(self, index: int) -> List[str]:
         """Return packet summaries starting from a given index."""
-        return [p.summary() for p in self.packets[index:]]
+        with self._lock:
+            return [p.summary() for p in self.packets[index:]]
 
     def get_connections(self) -> List[dict]:
         """Return a list of dicts with src and dst for IP packets."""
         connections = []
-        for p in self.packets:
-            if IP in p:
-                ip_layer = p[IP]
-                connections.append({"src": ip_layer.src, "dst": ip_layer.dst})
-        return connections
+        with self._lock:
+            for p in self.packets:
+                if IP in p:
+                    ip_layer = p[IP]
+                    connections.append({"src": ip_layer.src, "dst": ip_layer.dst})
+            return connections
 
     def get_connections_since(self, index: int) -> List[dict]:
         """Return src/dst dictionaries for packets since index."""
         connections = []
-        for p in self.packets[index:]:
-            if IP in p:
-                ip_layer = p[IP]
-                connections.append({"src": ip_layer.src, "dst": ip_layer.dst})
-        return connections
+        with self._lock:
+            for p in self.packets[index:]:
+                if IP in p:
+                    ip_layer = p[IP]
+                    connections.append({"src": ip_layer.src, "dst": ip_layer.dst})
+            return connections
 
     @property
     def size(self) -> int:
-        return len(self.packets)
+        with self._lock:
+            return len(self.packets)


### PR DESCRIPTION
## Summary
- guard PacketCapture operations with a threading lock
- add `_append_packet` helper for sniff callback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e1bb2e17483329b8beaae71b54603