### PR TITLE
Add packet counts to node titles

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -54,7 +54,16 @@ function update() {
   nodeEnter.select('circle')
     .attr('class', d => d.type === 'private' ? 'private' : null)
     .attr('fill', d => d.type === 'private' ? '#0f0' : '#0ff');
-  nodeEnter.selectAll('title').data(d => [d]).join('title').text(d => d.id);
+  nodeEnter.selectAll('title')
+    .data(d => [d])
+    .join('title')
+    .text(d => {
+      const outgoing = links.filter(l => l.source.id === d.id)
+                            .reduce((n, l) => n + l.count, 0);
+      const incoming = links.filter(l => l.target.id === d.id)
+                            .reduce((n, l) => n + l.count, 0);
+      return `${d.id}\nOut: ${outgoing}\nIn: ${incoming}`;
+    });
 
   simulation.nodes(dataNodes).on('tick', ticked);
   simulation.force('link').links(links);

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -61,7 +61,7 @@ circle.private {
 
 text.label {
     fill: #0ff;
-    font-size: 10px;
+    font-size: 12px;
     pointer-events: none;
     text-shadow: 0 0 2px #000;
 }


### PR DESCRIPTION
## Summary
- show per-node in/out packet counts via title attribute
- enlarge node label font

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e1bb3a3f08332a1ce56ee3c474658