### PR TITLE
Add map view with geolocation and anomalies

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ capture quelques instants et observez l’évolution du réseau !
 | 🔧 Phase 2 | API REST (FastAPI) exposant les flux | ✔️ |
 | 🔧 Phase 3 | Frontend minimal affichant les connexions | ✔️ |
 | 🔧 Phase 4 | Visualisation dynamique (D3.js) | ✔️ |
-| 🔧 Phase 5 | Détection d’anomalies réseau basiques | 🔜 |
-| 🌐 Phase 6 | Géolocalisation des IP et affichage sur carte | 🔜 |
+| 🔧 Phase 5 | Détection d’anomalies réseau basiques | ✔️ |
+| 🌐 Phase 6 | Géolocalisation des IP et affichage sur carte | ✔️ |
 | 📦 Phase 7 | Export JSON / PNG / GIF des sessions | 🔜 |
 
 ---

--- a/backend/geo.py
+++ b/backend/geo.py
@@ -1,0 +1,15 @@
+import requests
+from functools import lru_cache
+
+
+@lru_cache(maxsize=1024)
+def geolocate_ip(ip: str):
+    """Return (lat, lon, country) for an IP using ip-api.com."""
+    try:
+        resp = requests.get(f"http://ip-api.com/json/{ip}", timeout=5)
+        data = resp.json()
+        if data.get("status") == "success":
+            return data.get("lat"), data.get("lon"), data.get("country")
+    except Exception:
+        pass
+    return None, None, None

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,12 +1,12 @@
 const width = 800;
-const height = 600;
-const nodes = new Map();
-const links = [];
-const edges = new Map();
+const height = 500;
 
-const svg = d3.select('#graph').append('svg')
+const svg = d3.select('#map').append('svg')
   .attr('width', width)
   .attr('height', height);
+
+const projection = d3.geoMercator().scale(130).translate([width / 2, height / 1.5]);
+const path = d3.geoPath().projection(projection);
 
 svg.append('defs').append('marker')
   .attr('id', 'arrow')
@@ -20,123 +20,51 @@ svg.append('defs').append('marker')
   .attr('d', 'M0,-5L10,0L0,5')
   .attr('fill', '#f0f');
 
-const linkGroup = svg.append('g');
-const nodeGroup = svg.append('g');
+const linesGroup = svg.append('g');
 
-const simulation = d3.forceSimulation()
-  .force('link', d3.forceLink().id(d => d.id).distance(100))
-  .force('charge', d3.forceManyBody().strength(-100))
-  .force('center', d3.forceCenter(width / 2, height / 2))
-  .force('x', d3.forceX(width / 2).strength(0.05))
-  .force('y', d3.forceY(height / 2).strength(0.05));
+d3.json('https://cdn.jsdelivr.net/npm/world-atlas@2/countries-110m.json').then(world => {
+  const countries = topojson.feature(world, world.objects.countries);
+  svg.append('path')
+    .datum(countries)
+    .attr('d', path)
+    .attr('fill', '#111')
+    .attr('stroke', '#555');
+});
 
-function update() {
-  const dataNodes = Array.from(nodes.values());
-  const linkSel = linkGroup.selectAll('line')
-    .data(links)
-    .join('line')
-    .attr('stroke-width', d => Math.min(5, 1 + Math.log(d.count)));
-  linkSel.selectAll('title').data(d => [d]).join('title').text(d => `${d.source.id} -> ${d.target.id} (${d.count})`);
-
-  const nodeEnter = nodeGroup.selectAll('g')
-    .data(dataNodes)
-    .join(enter => {
-      const g = enter.append('g')
-        .call(drag(simulation));
-      g.append('circle')
-        .attr('r', 6);
-      g.append('text')
-        .attr('class', 'label')
-        .attr('x', 8)
-        .attr('y', 3)
-        .text(d => d.id);
-      g.on('click', (_, d) => showNodeInfo(d));
-      return g;
-    });
-  nodeEnter.select('circle')
-    .attr('class', d => d.type === 'private' ? 'private' : null)
-    .attr('fill', d => d.type === 'private' ? '#0f0' : '#0ff');
-  nodeEnter.selectAll('title')
-    .data(d => [d])
-    .join('title')
-    .text(d => {
-      const outgoing = links.filter(l => l.source.id === d.id)
-                            .reduce((n, l) => n + l.count, 0);
-      const incoming = links.filter(l => l.target.id === d.id)
-                            .reduce((n, l) => n + l.count, 0);
-      return `${d.id}\nOut: ${outgoing}\nIn: ${incoming}`;
-    });
-
-  simulation.nodes(dataNodes).on('tick', ticked);
-  simulation.force('link').links(links);
-  simulation.alpha(0.3).restart();
+function drawConnection(pkt) {
+  if (pkt.src_lat == null || pkt.dst_lat == null) return;
+  const feature = {
+    type: 'LineString',
+    coordinates: [
+      [pkt.src_lon, pkt.src_lat],
+      [pkt.dst_lon, pkt.dst_lat]
+    ]
+  };
+  linesGroup.append('path')
+    .datum(feature)
+    .attr('d', path)
+    .attr('class', 'connection');
 }
 
-function ticked() {
-  linkGroup.selectAll('line')
-    .attr('x1', d => d.source.x)
-    .attr('y1', d => d.source.y)
-    .attr('x2', d => d.target.x)
-    .attr('y2', d => d.target.y);
-  nodeGroup.selectAll('g')
-    .attr('transform', d => `translate(${d.x},${d.y})`);
+const logsEl = document.getElementById('logs');
+const anomaliesEl = document.getElementById('anomalies');
+
+function addLog(text) {
+  logsEl.textContent += text + '\n';
+  logsEl.scrollTop = logsEl.scrollHeight;
 }
 
-function drag(simulation) {
-  function dragstarted(event) {
-    if (!event.active) simulation.alphaTarget(0.3).restart();
-    event.subject.fx = event.subject.x;
-    event.subject.fy = event.subject.y;
-  }
-
-  function dragged(event) {
-    event.subject.fx = event.x;
-    event.subject.fy = event.y;
-  }
-
-  function dragended(event) {
-    if (!event.active) simulation.alphaTarget(0);
-    event.subject.fx = null;
-    event.subject.fy = null;
-  }
-
-  return d3.drag()
-    .on('start', dragstarted)
-    .on('drag', dragged)
-    .on('end', dragended);
+function addAnomaly(text) {
+  anomaliesEl.textContent += text + '\n';
+  anomaliesEl.scrollTop = anomaliesEl.scrollHeight;
 }
 
 const ws = new WebSocket(`ws://${location.host}/ws`);
 ws.onmessage = (event) => {
-  const packets = JSON.parse(event.data);
-  packets.forEach(pkt => {
-    const src = pkt.src;
-    const dst = pkt.dst;
-    if (!src || !dst) return;
-    if (!nodes.has(src)) nodes.set(src, {id: src, type: isPrivate(src) ? 'private' : 'public'});
-    if (!nodes.has(dst)) nodes.set(dst, {id: dst, type: isPrivate(dst) ? 'private' : 'public'});
-    const key = `${src}->${dst}`;
-    if (edges.has(key)) {
-      edges.get(key).count += 1;
-    } else {
-      const link = {source: nodes.get(src), target: nodes.get(dst), count: 1};
-      edges.set(key, link);
-      links.push(link);
-    }
+  const data = JSON.parse(event.data);
+  (data.packets || []).forEach(pkt => {
+    drawConnection(pkt);
+    addLog(`${pkt.src} -> ${pkt.dst}`);
   });
-  update();
+  (data.anomalies || []).forEach(a => addAnomaly(a));
 };
-
-function isPrivate(ip) {
-  return ip.startsWith('10.') ||
-         ip.startsWith('192.168.') ||
-         /^172\.(1[6-9]|2[0-9]|3[0-1])\./.test(ip);
-}
-
-const infoEl = document.getElementById('nodeInfo');
-
-function showNodeInfo(node) {
-  const outgoing = links.filter(l => l.source.id === node.id).map(l => l.target.id);
-  const incoming = links.filter(l => l.target.id === node.id).map(l => l.source.id);
-  infoEl.textContent = `IP: ${node.id}\nSortant: ${outgoing.join(', ')}\nEntrant: ${incoming.join(', ')}`;
-}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,12 +7,15 @@
 </head>
 <body>
     <h1>VISOR</h1>
-    <div id="graph"></div>
-    <div id="info">
-        <h2>Détails du noeud</h2>
-        <pre id="nodeInfo">Cliquez sur un noeud</pre>
+    <div id="map"></div>
+    <div id="sidebar">
+        <h2>Logs</h2>
+        <pre id="logs"></pre>
+        <h2>Anomalies</h2>
+        <pre id="anomalies"></pre>
     </div>
     <script src="/static/js/d3.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/topojson-client@3"></script>
     <script src="/static/app.js"></script>
 </body>
 </html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -14,22 +14,22 @@ h1 {
     text-shadow: 0 0 10px #0ff, 0 0 20px #0ff;
 }
 
-#graph {
+#map {
     display: inline-block;
 }
 
-#graph svg {
+#map svg {
     width: 800px;
-    height: 600px;
+    height: 500px;
     border: 1px solid #333;
     background-color: #000;
 }
 
-#info {
+#sidebar {
     display: inline-block;
     vertical-align: top;
     width: 300px;
-    height: 600px;
+    height: 500px;
     margin-left: 20px;
     padding: 10px;
     border: 1px solid #333;
@@ -38,7 +38,7 @@ h1 {
     overflow-y: auto;
 }
 
-#info pre {
+#sidebar pre {
     white-space: pre-wrap;
     word-break: break-all;
 }
@@ -64,4 +64,11 @@ text.label {
     font-size: 12px;
     pointer-events: none;
     text-shadow: 0 0 2px #000;
+}
+
+path.connection {
+    stroke: #f0f;
+    stroke-opacity: 0.6;
+    fill: none;
+    marker-end: url(#arrow);
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 scapy
 uvicorn[standard]
+requests

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -7,6 +7,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from fastapi.testclient import TestClient
 from backend import main
+from backend import geo
 
 class DummyCapture:
     def __init__(self):
@@ -30,8 +31,10 @@ class DummyCapture:
 def test_websocket_close(monkeypatch):
     dummy = DummyCapture()
     monkeypatch.setattr(main, "capture", dummy)
+    monkeypatch.setattr(geo, "geolocate_ip", lambda ip: (0, 0, ""))
     with TestClient(main.app) as client:
         with client.websocket_connect("/ws") as websocket:
             data = websocket.receive_json()
-            assert data == dummy.packets
+            assert "packets" in data
+            assert data["packets"][0]["src"] == "1.1.1.1"
             websocket.close()


### PR DESCRIPTION
## Summary
- add geolocation helper using ip-api.com
- enrich websocket messages with coordinates and basic anomaly detection
- add world map view with logs and anomalies
- update requirements and tests
- mark roadmap phases for anomalies and map as complete

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e222c05688332947d32c957e65e69