### PR TITLE
Use async httpx for IP geolocation

### DIFF
--- a/backend/geo.py
+++ b/backend/geo.py
@@ -1,15 +1,29 @@
-import requests
-from functools import lru_cache
+import asyncio
+import httpx
+
+_cache: dict[str, tuple | None] = {}
 
 
-@lru_cache(maxsize=1024)
-def geolocate_ip(ip: str):
-    """Return (lat, lon, country) for an IP using ip-api.com."""
+async def async_geolocate_ip(ip: str):
+    """Return (lat, lon, country) for an IP using ip-api.com asynchronously."""
+    if ip in _cache:
+        return _cache[ip]
     try:
-        resp = requests.get(f"http://ip-api.com/json/{ip}", timeout=5)
-        data = resp.json()
-        if data.get("status") == "success":
-            return data.get("lat"), data.get("lon"), data.get("country")
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(f"http://ip-api.com/json/{ip}", timeout=5)
+            data = resp.json()
+            if data.get("status") == "success":
+                result = (data.get("lat"), data.get("lon"), data.get("country"))
+            else:
+                result = (None, None, None)
     except Exception:
-        pass
-    return None, None, None
+        result = (None, None, None)
+    _cache[ip] = result
+    if len(_cache) > 1024:
+        _cache.pop(next(iter(_cache)))
+    return result
+
+
+def geolocate_ip(ip: str):
+    """Synchronous wrapper around :func:`async_geolocate_ip`."""
+    return asyncio.run(async_geolocate_ip(ip))

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,7 +6,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import JSONResponse, FileResponse
 
 from .capture import PacketCapture
-from .geo import geolocate_ip
+from .geo import async_geolocate_ip
 
 app = FastAPI(title="Visor")
 app.mount("/static", StaticFiles(directory="frontend"), name="static")
@@ -51,8 +51,8 @@ async def websocket_endpoint(ws: WebSocket):
             for pkt in new_packets:
                 src = pkt.get("src")
                 dst = pkt.get("dst")
-                slat, slon, _ = geolocate_ip(src)
-                dlat, dlon, _ = geolocate_ip(dst)
+                slat, slon, _ = await async_geolocate_ip(src)
+                dlat, dlon, _ = await async_geolocate_ip(dst)
                 info = {
                     "src": src,
                     "dst": dst,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fastapi
 scapy
 uvicorn[standard]
-requests
+httpx

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -7,7 +7,6 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from fastapi.testclient import TestClient
 from backend import main
-from backend import geo
 
 class DummyCapture:
     def __init__(self):
@@ -30,8 +29,11 @@ class DummyCapture:
 
 def test_websocket_close(monkeypatch):
     dummy = DummyCapture()
+    async def dummy_geo(ip):
+        return (0, 0, "")
+
     monkeypatch.setattr(main, "capture", dummy)
-    monkeypatch.setattr(geo, "geolocate_ip", lambda ip: (0, 0, ""))
+    monkeypatch.setattr(main, "async_geolocate_ip", dummy_geo)
     with TestClient(main.app) as client:
         with client.websocket_connect("/ws") as websocket:
             data = websocket.receive_json()


### PR DESCRIPTION
## Summary
- replace requests with httpx async client
- expose `async_geolocate_ip` helper
- await async geolocation in websocket handler
- update test patching and dependencies

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e7e0fc3148332b63ecd4c17bc8b6b