### PR TITLE
Visualize connection direction

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -40,10 +40,16 @@ function drawConnection(pkt) {
       [pkt.dst_lon, pkt.dst_lat]
     ]
   };
+  let color = '#f0f';
+  if (pkt.type === 'local-local') color = 'green';
+  else if (pkt.type === 'local-public') color = 'blue';
+  else if (pkt.type === 'public-local') color = 'red';
+
   linesGroup.append('path')
     .datum(feature)
     .attr('d', path)
-    .attr('class', 'connection');
+    .attr('class', 'connection')
+    .attr('stroke', color);
 }
 
 const logsEl = document.getElementById('logs');

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -37,4 +37,5 @@ def test_websocket_close(monkeypatch):
             data = websocket.receive_json()
             assert "packets" in data
             assert data["packets"][0]["src"] == "1.1.1.1"
+            assert "type" in data["packets"][0]
             websocket.close()


### PR DESCRIPTION
## Summary
- classify each connection as `local-local`, `local-public`, or `public-local`
- add connection type to packets sent through the websocket
- render lines in different colors depending on the type
- adjust tests for new data shape

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e7e2246cc8332a2c81e0696e93eb0