### PR TITLE
Add traffic type filters

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,6 +9,13 @@
     <h1>VISOR</h1>
     <div id="map"></div>
     <div id="sidebar">
+        <h2>Filters</h2>
+        <div id="filters">
+            <label><input type="checkbox" id="private-private" checked> Private ➜ Private</label><br>
+            <label><input type="checkbox" id="private-public" checked> Private ➜ Public</label><br>
+            <label><input type="checkbox" id="public-private" checked> Public ➜ Private</label><br>
+            <label><input type="checkbox" id="public-public" checked> Public ➜ Public</label>
+        </div>
         <h2>Logs</h2>
         <pre id="logs"></pre>
         <h2>Anomalies</h2>


### PR DESCRIPTION
## Summary
- add traffic filter checkboxes
- skip rendering connections that don't match selected traffic types

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e7e24b68c8332b5c776af87e7ff96