### PR TITLE
Pin httpx version in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fastapi
 scapy
 uvicorn[standard]
-httpx
+httpx>=0.24,<0.25


### PR DESCRIPTION
## Summary
- pin `httpx` in `requirements.txt` to match `requirements-dev.txt`
- run tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e8c8882f88332b9ea1a76a578f49f