### PR TITLE
Switch IP geolocation fetch to HTTPS

### DIFF
--- a/backend/geo.py
+++ b/backend/geo.py
@@ -10,7 +10,7 @@ async def async_geolocate_ip(ip: str):
         return _cache[ip]
     try:
         async with httpx.AsyncClient() as client:
-            resp = await client.get(f"http://ip-api.com/json/{ip}", timeout=5)
+            resp = await client.get(f"https://ip-api.com/json/{ip}", timeout=5)
             data = resp.json()
             if data.get("status") == "success":
                 result = (


### PR DESCRIPTION
## Summary
- use an HTTPS endpoint for IP geolocation

## Testing
- `pytest -q`
- `python - <<'PY'
import asyncio
from backend.geo import async_geolocate_ip
async def main():
    print(await async_geolocate_ip('8.8.8.8'))
asyncio.run(main())
PY`

------
https://chatgpt.com/codex/tasks/task_e_684e8c9f6fc88332ab68701fcbf252f7