### PR TITLE
Switch geolocation to HTTP

### DIFF
--- a/backend/geo.py
+++ b/backend/geo.py
@@ -10,7 +10,7 @@ async def async_geolocate_ip(ip: str):
         return _cache[ip]
     try:
         async with httpx.AsyncClient() as client:
-            resp = await client.get(f"https://ip-api.com/json/{ip}", timeout=5)
+            resp = await client.get(f"http://ip-api.com/json/{ip}", timeout=5)
             data = resp.json()
             if data.get("status") == "success":
                 result = (

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -1,0 +1,15 @@
+import pytest
+import httpx
+import asyncio
+from backend.geo import async_geolocate_ip
+
+
+def test_async_geolocate_ip_known_address():
+    try:
+        lat, lon, country, cc = asyncio.run(async_geolocate_ip("8.8.8.8"))
+    except httpx.HTTPError:
+        pytest.skip("Network not accessible")
+    if lat is None or lon is None:
+        pytest.skip("Geolocation service unavailable")
+    assert -90 <= lat <= 90
+    assert -180 <= lon <= 180


### PR DESCRIPTION
## Summary
- use `http://ip-api.com` for IP lookup
- add tests for real geolocation when network is available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e8e83eaa08332b2143be7f5a96721