### PR TITLE
Switch geolocation to HTTP

### DIFF
--- a/backend/geo.py
+++ b/backend/geo.py
@@ -10,7 +10,7 @@ async def async_geolocate_ip(ip: str):
         return _cache[ip]
     try:
         async with httpx.AsyncClient() as client:
-            resp = await client.get(f"https://ip-api.com/json/{ip}", timeout=5)
+            resp = await client.get(f"http://ip-api.com/json/{ip}", timeout=5)
             data = resp.json()
             if data.get("status") == "success":
                 result = (

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -1,0 +1,13 @@
+import pytest
+import asyncio
+from backend.geo import async_geolocate_ip
+
+def test_async_geolocate_ip_live():
+    try:
+        lat, lon, *_ = asyncio.run(async_geolocate_ip("8.8.8.8"))
+    except Exception:
+        pytest.skip("Network unreachable")
+    if lat is None or lon is None:
+        pytest.skip("API did not return location")
+    assert isinstance(lat, float)
+    assert isinstance(lon, float)


### PR DESCRIPTION
## Summary
- switch geolocation API to HTTP
- add integration test for async_geolocate_ip when network is present

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e8f085d5883329a283283b344b316