### PR TITLE
Remove arrow marker and adjust CSS

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -24,18 +24,6 @@ const projection = d3.geoMercator();
 projection.fitSize([width, height], {type: 'Sphere'});
 const path = d3.geoPath().projection(projection);
 
-svg.append('defs').append('marker')
-  .attr('id', 'arrow')
-  .attr('viewBox', '0 -5 10 10')
-  .attr('refX', 10)
-  .attr('refY', 0)
-  .attr('markerWidth', 6)
-  .attr('markerHeight', 6)
-  .attr('orient', 'auto')
-  .append('path')
-  .attr('d', 'M0,-5L10,0L0,5')
-  .attr('fill', '#f0f');
-
 // enable zoom and pan on the map
 const zoom = d3.zoom()
   .scaleExtent([1, 8])

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -83,7 +83,7 @@ h1 {
 line {
     stroke: #f0f;
     stroke-opacity: 0.6;
-    marker-end: url(#arrow);
+    stroke-linecap: round;
 }
 
 circle {
@@ -107,6 +107,6 @@ path.connection {
     stroke: #f0f;
     stroke-opacity: 0.6;
     fill: none;
-    marker-end: url(#arrow);
+    stroke-linecap: round;
     transition: opacity 1s ease-out;
 }


### PR DESCRIPTION
## Summary
- remove creation of `arrow` marker from the frontend JavaScript
- drop `marker-end` from `.connection` and clean up line styling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e9876e3e88332a4e2060f93b7aadb