### PR TITLE
Handle server geolocation

### DIFF
--- a/backend/host.py
+++ b/backend/host.py
@@ -1,0 +1,13 @@
+import httpx
+
+
+async def get_public_ip() -> str | None:
+    """Return the public IP address of the host as a string."""
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get("https://api.ipify.org?format=json", timeout=5)
+            resp.raise_for_status()
+            data = resp.json()
+            return data.get("ip")
+    except Exception:
+        return None


### PR DESCRIPTION
## Summary
- add `get_public_ip` helper
- locate the server on startup and reuse its coords for local IPs
- expose server location info to websocket clients
- draw local connections from server position on the frontend

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e98784cf88332a2e68496dfa4b17f