### PR TITLE
Enable zooming for graph network

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -51,8 +51,14 @@ const activeConnections = new Map();
 const graphNodes = new Map();
 let graphLinks = [];
 const MAX_TABLE_ROWS = 50;
-const linkGroup = gsvg.append('g');
-const nodeGroup = gsvg.append('g');
+const graphZoomGroup = gsvg.append('g');
+const linkGroup = graphZoomGroup.append('g');
+const nodeGroup = graphZoomGroup.append('g');
+
+const graphZoom = d3.zoom()
+  .scaleExtent([0.5, 5])
+  .on('zoom', e => graphZoomGroup.attr('transform', e.transform));
+gsvg.call(graphZoom);
 const simulation = d3.forceSimulation()
   .force('link', d3.forceLink().id(d => d.id).distance(60))
   .force('charge', d3.forceManyBody().strength(-100))

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -45,6 +45,10 @@ h1 {
     background-color: #000;
 }
 
+#graph line, #graph circle {
+    vector-effect: non-scaling-stroke;
+}
+
 #sidebar {
     height: 100%;
     margin-left: 20px;


### PR DESCRIPTION
## Summary
- group graph nodes and links under `graphZoomGroup`
- add zoom behavior to graph with scale from 0.5 to 5
- keep stroke width consistent while zooming

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e987b5220833294e16c86b7c22f4f