### PR TITLE
Improve dashboard UI

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -23,6 +23,14 @@ const gsvg = d3.select('#graph').append('svg')
   .attr('width', '100%')
   .attr('height', '100%');
 
+const sidebarEl = document.getElementById('sidebar');
+const toggleSidebarBtn = document.getElementById('toggleSidebar');
+if (toggleSidebarBtn) {
+  toggleSidebarBtn.addEventListener('click', () => {
+    sidebarEl.classList.toggle('collapsed');
+  });
+}
+
 const projection = d3.geoMercator();
 projection.fitSize([width, height], {type: 'Sphere'});
 const path = d3.geoPath().projection(projection);
@@ -78,13 +86,19 @@ const filters = {
 };
 
 const colorMap = {
-  'local-local': 'green',
-  'local-public': 'blue',
-  'public-local': 'red',
+  'local-local': '#0f0',
+  'local-public': '#2af',
+  'public-local': '#f44',
   'public-public': '#f0f'
 };
 
 let serverPos = {lat: 0, lon: 0};
+
+function highlightNode(ip, on) {
+  nodeGroup.selectAll('circle')
+    .filter(d => d.id === ip)
+    .classed('highlight', on);
+}
 
 // Initialize checkbox listeners
 document.querySelectorAll('#filters input[type="checkbox"]').forEach(cb => {
@@ -264,6 +278,16 @@ function updateConnection(pkt) {
     const tr = document.createElement('tr');
     tr.innerHTML = rowHtml;
     tr.style.color = colorMap[pkt.type] || '#f0f';
+    tr.dataset.src = pkt.src;
+    tr.dataset.dst = pkt.dst;
+    tr.addEventListener('mouseenter', () => {
+      highlightNode(tr.dataset.src, true);
+      highlightNode(tr.dataset.dst, true);
+    });
+    tr.addEventListener('mouseleave', () => {
+      highlightNode(tr.dataset.src, false);
+      highlightNode(tr.dataset.dst, false);
+    });
     connectionTableBody.appendChild(tr);
     while (connectionTableBody.rows.length > MAX_TABLE_ROWS) {
       connectionTableBody.deleteRow(0);
@@ -273,6 +297,8 @@ function updateConnection(pkt) {
   } else {
     rec.tr.innerHTML = rowHtml;
     rec.tr.style.color = colorMap[pkt.type] || '#f0f';
+    rec.tr.dataset.src = pkt.src;
+    rec.tr.dataset.dst = pkt.dst;
   }
   rec.timestamp = now;
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,16 +6,19 @@
     <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-    <h1>VISOR</h1>
+    <header>
+        <h1>VISOR</h1>
+        <button id="toggleSidebar">☰</button>
+    </header>
     <div id="container">
         <div id="map"></div>
         <div id="graph"></div>
         <div id="sidebar">
         <h2>Filters</h2>
         <div id="filters">
-            <label><input type="checkbox" id="private-private" checked> Private ➜ Private</label><br>
-            <label><input type="checkbox" id="private-public" checked> Private ➜ Public</label><br>
-            <label><input type="checkbox" id="public-private" checked> Public ➜ Private</label><br>
+            <label><input type="checkbox" id="private-private" checked> Private ➜ Private</label>
+            <label><input type="checkbox" id="private-public" checked> Private ➜ Public</label>
+            <label><input type="checkbox" id="public-private" checked> Public ➜ Private</label>
             <label><input type="checkbox" id="public-public" checked> Public ➜ Public</label>
         </div>
         <h2>Active Connections</h2>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,9 +1,9 @@
-@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Inter:wght@400;600;700&display=swap');
 
 body {
     background-color: #0d0d0d;
-    color: #0ff;
-    font-family: 'Orbitron', sans-serif;
+    color: #2af;
+    font-family: 'Inter', sans-serif;
     margin: 0;
     padding: 0;
     height: 100vh;
@@ -14,7 +14,27 @@ body {
 h1 {
     text-align: center;
     margin-bottom: 20px;
-    text-shadow: 0 0 10px #0ff, 0 0 20px #0ff;
+    font-family: 'Orbitron', sans-serif;
+    text-shadow: 0 0 10px #2af, 0 0 20px #2af;
+}
+
+header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 20px;
+    background: #111;
+    color: #2af;
+    box-shadow: 0 0 5px #2af;
+}
+
+#toggleSidebar {
+    background: none;
+    border: 1px solid #2af;
+    color: #2af;
+    padding: 4px 8px;
+    font-family: 'Orbitron', sans-serif;
+    cursor: pointer;
 }
 
 #container {
@@ -50,14 +70,30 @@ h1 {
 }
 
 #sidebar {
+    width: 260px;
     height: 100%;
     margin-left: 20px;
     padding: 10px;
     box-sizing: border-box;
     border: 1px solid #333;
     background: rgba(0, 0, 0, 0.5);
-    color: #0ff;
+    color: #2af;
     overflow-y: auto;
+    transition: transform 0.3s ease;
+}
+
+#sidebar.collapsed {
+    transform: translateX(100%);
+}
+
+#filters label {
+    display: inline-block;
+    margin-bottom: 6px;
+    cursor: pointer;
+}
+
+#filters input {
+    margin-right: 6px;
 }
 
 #sidebar pre {
@@ -77,6 +113,10 @@ h1 {
     text-align: left;
 }
 
+#connections tr:hover {
+    background: rgba(255, 255, 255, 0.1);
+}
+
 .flag {
     width: 16px;
     height: 12px;
@@ -91,7 +131,7 @@ line {
 }
 
 circle {
-    fill: #0ff;
+    fill: #2af;
     stroke: #000;
     stroke-width: 0.5px;
 }
@@ -101,7 +141,7 @@ circle.private {
 }
 
 text.label {
-    fill: #0ff;
+    fill: #2af;
     font-size: 12px;
     pointer-events: none;
     text-shadow: 0 0 2px #000;
@@ -113,4 +153,25 @@ path.connection {
     fill: none;
     stroke-linecap: round;
     transition: opacity 1s ease-out;
+}
+
+circle.highlight {
+    stroke: #fff;
+    stroke-width: 3px;
+}
+
+@media (max-width: 800px) {
+    #container {
+        flex-direction: column;
+    }
+    #map, #graph {
+        flex: none;
+        height: 300px;
+        margin: 0 0 20px 0;
+    }
+    #sidebar {
+        width: 100%;
+        margin-left: 0;
+        height: auto;
+    }
 }


### PR DESCRIPTION
## Summary
- revamp the dashboard layout with a header and a collapsible sidebar
- introduce Inter font for text and tweak colour palette
- add responsive layout and hover highlights for graph nodes

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e9eaf8a50833290679c3638c79abd