### PR TITLE
Limit PacketCapture history

### DIFF
--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from backend.capture import PacketCapture
+
+
+def test_max_packets_drops_old():
+    cap = PacketCapture(max_packets=2)
+    cap._append_packet("one")
+    cap._append_packet("two")
+    cap._append_packet("three")
+    with cap._lock:
+        pkts = list(cap.packets)
+    assert pkts == ["two", "three"]
+    assert cap.size == 2


### PR DESCRIPTION
## Summary
- keep only the latest packets by storing them in a deque
- add `max_packets` option to `PacketCapture`
- adjust slice operations for deque
- test that older packets are dropped

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ea196b4b88332a5fe765e75f67ccb