### PR TITLE
Improve anomaly detection system

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,21 @@ Visor s'appuie désormais sur un moteur de règles extensible. Par défaut, quel
 - pic soudain de destinations différentes pour une même source ;
 - scan répété de ports sur une cible ;
 - protocoles inhabituels (autres que TCP/UDP/ICMP).
+- accumulation de sources variées vers une même destination (détection DDoS).
 
 La communauté peut facilement ajouter de nouvelles règles en implémentant des classes héritant de `AnomalyRule` dans le dossier `backend`. Il suffit ensuite de les enregistrer dans `AnomalyDetector` pour qu'elles soient prises en compte.
+
+Les seuils des règles peuvent être ajustés et certaines règles désactivées en créant un fichier `anomaly_config.json`. Celui-ci sera chargé au démarrage si la variable d'environnement `ANOMALY_CONFIG` est définie ou s'il est placé à la racine du projet. Exemple :
+
+```json
+{
+  "rules": {
+    "HighTrafficRule": {"threshold": 100},
+    "PortScanRule": false
+  }
+}
+```
+
 
 ---
 

--- a/anomaly_config.json.example
+++ b/anomaly_config.json.example
@@ -1,0 +1,9 @@
+{
+  "rules": {
+    "HighTrafficRule": {"threshold": 100},
+    "DestinationSpikeRule": {"spike_threshold": 20},
+    "PortScanRule": {"threshold": 10},
+    "UnusualProtocolRule": {"allowed": ["TCP", "UDP", "ICMP"]},
+    "DDosTargetRule": {"threshold": 50}
+  }
+}

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,33 @@
+import os
+import json
+from pathlib import Path
+
+DEFAULT_CONFIG_FILE = "anomaly_config.json"
+
+
+def load_anomaly_config(path: str | None = None) -> dict:
+    """Load anomaly detection configuration from JSON file.
+
+    Parameters
+    ----------
+    path: str | None
+        Path to the configuration file. If not provided, the path is taken
+        from the ``ANOMALY_CONFIG`` environment variable or defaults to
+        ``anomaly_config.json`` in the working directory.
+    Returns
+    -------
+    dict
+        Configuration dictionary. If the file doesn't exist or is invalid,
+        an empty dictionary is returned.
+    """
+    if path is None:
+        path = os.getenv("ANOMALY_CONFIG", DEFAULT_CONFIG_FILE)
+    try:
+        data = json.loads(Path(path).read_text())
+        if isinstance(data, dict):
+            return data
+    except FileNotFoundError:
+        pass
+    except Exception:
+        pass
+    return {}

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,7 @@
 import asyncio
 
-from .anomaly import AnomalyDetector
+from .anomaly import AnomalyDetector, create_detector_from_config
+from .config import load_anomaly_config
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.staticfiles import StaticFiles
@@ -14,7 +15,8 @@ from .geo import async_geolocate_ip, is_local_ip
 from . import geo
 
 capture = PacketCapture()
-detector = AnomalyDetector()
+_config = load_anomaly_config()
+detector = create_detector_from_config(_config)
 
 
 server_geolocation: tuple[float | None, float | None, str | None, str | None] = (

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -1,6 +1,9 @@
+from pathlib import Path
+import sys
 import pytest
 import httpx
 import asyncio
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from backend.geo import async_geolocate_ip
 
 


### PR DESCRIPTION
## Summary
- add configuration loader for anomaly rules
- allow building `AnomalyDetector` from JSON config
- implement `DDosTargetRule`
- make backend load config on start
- document configuration in README
- provide example config file
- test detector configuration
- fix geo test imports

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_capture.py tests/test_geo.py -q`
- `pytest tests/test_app.py::test_packet_capture_stop tests/test_app.py::test_anomaly_detector_config -q`


------
https://chatgpt.com/codex/tasks/task_e_684f1a0e58d08332b75d8fba3219d657