### PR TITLE
Scope SVG styles for graph and map

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -124,13 +124,15 @@ header {
     margin-right: 4px;
 }
 
-line {
+#graph line,
+#map line {
     stroke: #f0f;
     stroke-opacity: 0.6;
     stroke-linecap: round;
 }
 
-circle {
+#graph circle,
+#map circle {
     fill: #2af;
     stroke: #000;
     stroke-width: 0.5px;


### PR DESCRIPTION
## Summary
- limit `line` and `circle` styling to elements inside `#map` and `#graph`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f1e3fad44833292e74cb8e3c32522