### PR TITLE
Improve sidebar usability

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,15 +17,19 @@
         <div id="sidebar">
         <h2>Filters</h2>
         <div id="filters">
-            <label><input type="checkbox" id="private-private" checked> Private ➜ Private</label>
-            <label><input type="checkbox" id="private-public" checked> Private ➜ Public</label>
-            <label><input type="checkbox" id="public-private" checked> Public ➜ Private</label>
-            <label><input type="checkbox" id="public-public" checked> Public ➜ Public</label>
+            <label><input type="checkbox" id="private-private" checked> LAN ➜ LAN</label>
+            <label><input type="checkbox" id="private-public" checked> LAN ➜ WAN</label>
+            <label><input type="checkbox" id="public-private" checked> WAN ➜ LAN</label>
+            <label><input type="checkbox" id="public-public" checked> WAN ➜ WAN</label>
         </div>
+        <label id="colorblind-wrapper"><input type="checkbox" id="colorblind-toggle"> Daltonism mode</label>
+        <input type="text" id="search" placeholder="Search IP">
         <h2>Active Connections</h2>
         <table id="connections">
             <thead>
-                <tr><th>Source</th><th></th><th>Destination</th><th>Proto</th></tr>
+                <tr>
+                    <th></th><th>Source</th><th></th><th></th><th>Destination</th><th>Proto</th>
+                </tr>
             </thead>
             <tbody></tbody>
         </table>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,5 +1,19 @@
 @import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Inter:wght@400;600;700&display=swap');
 
+:root {
+    --color-local-local: #0f0;
+    --color-local-public: #2af;
+    --color-public-local: #f44;
+    --color-public-public: #f0f;
+}
+
+body.colorblind {
+    --color-local-local: #00bcd4;
+    --color-local-public: #ff9800;
+    --color-public-local: #ff9800;
+    --color-public-public: #00bcd4;
+}
+
 body {
     background-color: #0d0d0d;
     color: #2af;
@@ -35,6 +49,11 @@ header {
     padding: 4px 8px;
     font-family: 'Orbitron', sans-serif;
     cursor: pointer;
+}
+
+:focus {
+    outline: 2px solid #ff9800;
+    outline-offset: 2px;
 }
 
 #container {
@@ -96,6 +115,17 @@ header {
     margin-right: 6px;
 }
 
+#colorblind-wrapper {
+    display: block;
+    margin: 6px 0;
+}
+
+#search {
+    width: 100%;
+    margin: 6px 0;
+    box-sizing: border-box;
+}
+
 #sidebar pre {
     white-space: pre-wrap;
     word-break: break-all;
@@ -107,10 +137,17 @@ header {
     margin-bottom: 10px;
 }
 
+#connections thead th {
+    position: sticky;
+    top: 0;
+    background: #111;
+}
+
 #connections th, #connections td {
     border-bottom: 1px solid #333;
-    padding: 4px;
+    padding: 6px 4px;
     text-align: left;
+    line-height: 24px;
 }
 
 #connections tr:hover {
@@ -122,6 +159,15 @@ header {
     height: 12px;
     vertical-align: middle;
     margin-right: 4px;
+}
+
+.badge {
+    background: #222;
+    color: #fff;
+    padding: 2px 4px;
+    border-radius: 3px;
+    font-size: 12px;
+    font-weight: 600;
 }
 
 #graph line,


### PR DESCRIPTION
## Summary
- tweak filters and add search box in sidebar
- add colorblind mode toggle
- adjust table layout with sticky header and protocol badges
- update styling for focus outlines and spacing
- generate colors from CSS variables in JS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f3342dcf08332bc90ff62c71fcb0f